### PR TITLE
hack: add verification scripts for CI

### DIFF
--- a/hack/update-all.sh
+++ b/hack/update-all.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# script to run all update scripts (except deps)
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# shellcheck source=/dev/null
+source "$(dirname "$0")/utils.sh"
+REPO_PATH=$(get_root_path)
+
+"${REPO_PATH}"/hack/update-deps.sh
+"${REPO_PATH}"/hack/update-gofmt.sh

--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Runs go mod tidy, go mod vendor, and then prun vendor
+#
+# Usage:
+#   update-deps.sh
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+# shellcheck source=/dev/null
+source "$(dirname "$0")/utils.sh"
+# cd to the root path
+cd_root_path
+
+prune-vendor() {
+  find vendor -type f \
+    -not -iname "*.c" \
+    -not -iname "*.go" \
+    -not -iname "*.h" \
+    -not -iname "*.proto" \
+    -not -iname "*.s" \
+    -not -iname "AUTHORS*" \
+    -not -iname "CONTRIBUTORS*" \
+    -not -iname "COPYING*" \
+    -not -iname "LICENSE*" \
+    -not -iname "NOTICE*" \
+    -exec rm '{}' \;
+}
+
+export GO111MODULE="on"
+go mod tidy

--- a/hack/update-gofmt.sh
+++ b/hack/update-gofmt.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# script to run gofmt over our code (not vendor)
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# shellcheck source=/dev/null
+source "$(dirname "$0")/utils.sh"
+# cd to the root path
+cd_root_path
+
+# update go fmt
+go fmt ./...

--- a/hack/utils.sh
+++ b/hack/utils.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# get_root_path returns the root path of the kinder source tree
+get_root_path() {
+    echo "$(git rev-parse --show-toplevel)"
+}
+
+# cd_root_path cds to the root path of the kinder source tree
+cd_root_path() {
+    cd "$(get_root_path)" || exit
+}

--- a/hack/verify-all.sh
+++ b/hack/verify-all.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# shellcheck source=/dev/null
+source "$(dirname "$0")/utils.sh"
+
+# set REPO_PATH
+REPO_PATH=$(get_root_path)
+cd "${REPO_PATH}"
+
+# exit code, if a script fails we'll set this to 1
+res=0
+
+# run all verify scripts, optionally skipping any of them
+
+if [[ "${VERIFY_WHITESPACE:-true}" == "true" ]]; then
+  echo "[*] Verifying whitespace..."
+  hack/verify-whitespace.sh || res=1
+  cd "${REPO_PATH}"
+fi
+
+if [[ "${VERIFY_SPELLING:-true}" == "true" ]]; then
+  echo "[*] Verifying spelling..."
+  hack/verify-spelling.sh || res=1
+  cd "${REPO_PATH}"
+fi
+
+if [[ "${VERIFY_BOILERPLATE:-true}" == "true" ]]; then
+  echo "[*] Verifying boilerplate..."
+  hack/verify-boilerplate.sh || res=1
+  cd "${REPO_PATH}"
+fi
+
+if [[ "${VERIFY_GOFMT:-true}" == "true" ]]; then
+  echo "[*] Verifying gofmt..."
+  hack/verify-gofmt.sh || res=1
+  cd "${REPO_PATH}"
+fi
+
+if [[ "${VERIFY_GOLINT:-true}" == "true" ]]; then
+  echo "[*] Verifying golint..."
+  hack/verify-golint.sh || res=1
+  cd "${REPO_PATH}"
+fi
+
+if [[ "${VERIFY_GOVET:-true}" == "true" ]]; then
+  echo "[*] Verifying govet..."
+  hack/verify-govet.sh || res=1
+  cd "${REPO_PATH}"
+fi
+
+if [[ "${VERIFY_DEPS:-true}" == "true" ]]; then
+  echo "[*] Verifying deps..."
+  hack/verify-deps.sh || res=1
+  cd "${REPO_PATH}"
+fi
+
+if [[ "${VERIFY_GOTEST:-true}" == "true" ]]; then
+  echo "[*] Verifying gotest..."
+  hack/verify-gotest.sh || res=1
+  cd "${REPO_PATH}"
+fi
+
+# exit based on verify scripts
+if [[ "${res}" = 0 ]]; then
+  echo ""
+  echo "All verify checks passed, congrats!"
+else
+  echo ""
+  echo "One or more verify checks failed! See output above..."
+fi
+exit "${res}"

--- a/hack/verify-boilerplate.go
+++ b/hack/verify-boilerplate.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"regexp"
+	"strings"
+)
+
+const (
+	yearPlaceholder  = "YEAR"
+	boilerPlateStart = "Copyright "
+	boilerPlateEnd   = "limitations under the License."
+)
+
+var (
+	supportedExt = []string{".go", ".py", ".sh"}
+	yearRegexp   = regexp.MustCompile("(20)[0-9][0-9]")
+	boilerPlate  = []string{
+		boilerPlateStart + yearPlaceholder + " The Kubernetes Authors.",
+		"",
+		`Licensed under the Apache License, Version 2.0 (the "License");`,
+		"you may not use this file except in compliance with the License.",
+		"You may obtain a copy of the License at",
+		"",
+		"    http://www.apache.org/licenses/LICENSE-2.0",
+		"",
+		"Unless required by applicable law or agreed to in writing, software",
+		`distributed under the License is distributed on an "AS IS" BASIS,`,
+		"WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.",
+		"See the License for the specific language governing permissions and",
+		boilerPlateEnd,
+	}
+)
+
+// trimLeadingComment strips a single line comment characters such as # or //
+// at the exact beginning of a line, but also the first possible space character after it.
+func trimLeadingComment(line, c string) string {
+	if strings.Index(line, c) == 0 {
+		x := len(c)
+		if len(line) == x {
+			return ""
+		}
+		if line[x] == byte(' ') {
+			return line[x+1:]
+		}
+		return line[x:]
+	}
+	return line
+}
+
+// verifyFileExtension verifies if the file extensions is supported
+func isSupportedFileExtension(filePath string) bool {
+	// check if the file has an extension
+	idx := strings.LastIndex(filePath, ".")
+	if idx == -1 {
+		return false
+	}
+
+	// check if the file has a supported extension
+	ext := filePath[idx : idx+len(filePath)-idx]
+	for _, e := range supportedExt {
+		if e == ext {
+			return true
+		}
+	}
+	return false
+}
+
+// verifyBoilerplate verifies if a string contains the boilerplate
+func verifyBoilerplate(contents string) error {
+	idx := 0
+	foundBoilerplateStart := false
+	lines := strings.Split(contents, "\n")
+	for _, line := range lines {
+		// handle leading comments
+		line = trimLeadingComment(line, "//")
+		line = trimLeadingComment(line, "#")
+
+		// find the start of the boilerplate
+		bpLine := boilerPlate[idx]
+		if strings.Contains(line, boilerPlateStart) {
+			foundBoilerplateStart = true
+
+			// validate the year of the copyright
+			yearWords := strings.Split(line, " ")
+			expectedLen := len(strings.Split(boilerPlate[0], " "))
+			if len(yearWords) != expectedLen {
+				return fmt.Errorf("copyright line should contain exactly %d words", expectedLen)
+			}
+			if !yearRegexp.MatchString(yearWords[1]) {
+				return fmt.Errorf("cannot parse the year in the copyright line")
+			}
+			bpLine = strings.ReplaceAll(bpLine, yearPlaceholder, yearWords[1])
+		}
+
+		// match line by line
+		if foundBoilerplateStart {
+			if line != bpLine {
+				return fmt.Errorf("boilerplate line %d does not match\nexpected: %q\ngot: %q", idx+1, bpLine, line)
+			}
+			idx++
+			// exit after the last line is found
+			if strings.Index(line, boilerPlateEnd) == 0 {
+				break
+			}
+		}
+	}
+
+	if !foundBoilerplateStart {
+		return errors.New("the file is missing a boilerplate")
+	}
+	if idx < len(boilerPlate) {
+		return errors.New("boilerplate has missing lines")
+	}
+	return nil
+}
+
+// verifyFile verifies if a file contains the boilerplate
+func verifyFile(filePath string) error {
+	if len(filePath) == 0 {
+		return errors.New("empty file name")
+	}
+
+	if !isSupportedFileExtension(filePath) {
+		fmt.Printf("skipping %q: unsupported file type\n", filePath)
+		return nil
+	}
+
+	// read the file
+	b, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return err
+	}
+
+	return verifyBoilerplate(string(b))
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: " +
+			"go run verify-boilerplate.go <path-to-file> <path-to-file> ...")
+		os.Exit(1)
+	}
+
+	hasErr := false
+	for _, filePath := range os.Args[1:] {
+		if err := verifyFile(filePath); err != nil {
+			fmt.Printf("error validating %q: %v\n", filePath, err)
+			hasErr = true
+		}
+	}
+	if hasErr {
+		os.Exit(1)
+	}
+}

--- a/hack/verify-boilerplate.sh
+++ b/hack/verify-boilerplate.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# shellcheck source=/dev/null
+source "$(dirname "$0")/utils.sh"
+# cd to the root path
+cd_root_path
+
+git ls-files | grep -v "vendor\/" | xargs go run ./hack/verify-boilerplate.go

--- a/hack/verify-boilerplate_test.go
+++ b/hack/verify-boilerplate_test.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+)
+
+func TestVerifyBoilerPlate(t *testing.T) {
+	testcases := []struct {
+		name          string
+		bp            string
+		expectedError bool
+	}{
+		{
+			name: "valid: boilerplate is valid",
+			bp: `\/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+		*/`,
+			expectedError: false,
+		},
+		{
+			name: "invalid: missing lines",
+			bp: `
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+`,
+			expectedError: true,
+		},
+		{
+			name:          "invalid: bad year",
+			bp:            "Copyright 1019 The Kubernetes Authors.",
+			expectedError: true,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := verifyBoilerplate(tc.bp); err != nil != tc.expectedError {
+				t.Errorf("expected error: %v, got: %v, error: %v", tc.expectedError, err != nil, err)
+			}
+		})
+	}
+}
+
+func TestTrimLeadingComment(t *testing.T) {
+	testcases := []struct {
+		name           string
+		comment        string
+		line           string
+		expectedResult string
+	}{
+		{
+			name:           "trim leading comment",
+			comment:        "#",
+			line:           "# test",
+			expectedResult: "test",
+		},
+		{
+			name:           "empty line",
+			comment:        "#",
+			line:           "#",
+			expectedResult: "",
+		},
+		{
+			name:           "trim leading comment and space",
+			comment:        "//",
+			line:           "// test",
+			expectedResult: "test",
+		},
+		{
+			name:           "no comment",
+			comment:        "//",
+			line:           "test",
+			expectedResult: "test",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			if res := trimLeadingComment(tc.line, tc.comment); res != tc.expectedResult {
+				t.Errorf("expected: %q, got: %q", tc.expectedResult, res)
+			}
+		})
+	}
+}

--- a/hack/verify-deps.sh
+++ b/hack/verify-deps.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o nounset
+set -o pipefail
+
+# shellcheck source=/dev/null
+source "$(dirname "$0")/utils.sh"
+# cd to the root path
+cd_root_path
+
+# cleanup on exit
+cleanup() {
+  echo "Cleaning up..."
+  mv go.mod.old go.mod
+  mv go.sum.old go.sum
+}
+trap cleanup EXIT
+
+echo "Verifying..."
+# temporary copy the go mod and sum files
+cp go.mod go.mod.old || exit
+cp go.sum go.sum.old || exit
+
+# run update-deps.sh
+export GO111MODULE="on"
+./hack/update-deps.sh
+
+# compare the old and new files
+DIFF0=$(diff -u go.mod go.mod.old)
+DIFF1=$(diff -u go.sum go.sum.old)
+
+if [[ -n "${DIFF0}" ]] || [[ -n "${DIFF1}" ]]; then
+  echo "${DIFF0}"
+  echo "${DIFF1}"
+  echo "Check failed. Please run ./hack/update-deps.sh"
+  exit 1
+fi

--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# shellcheck source=/dev/null
+source "$(dirname "$0")/utils.sh"
+# cd to the root path
+cd_root_path
+
+# check for gofmt diffs
+diff=$(git ls-files | grep "\.go" | grep -v "vendor\/" | xargs gofmt -s -d 2>&1)
+if [[ -n "${diff}" ]]; then
+  echo "${diff}"
+  echo
+  echo "Check failed. Please run hack/update-gofmt.sh"
+  exit 1
+fi

--- a/hack/verify-golint.sh
+++ b/hack/verify-golint.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# CI script to run go lint over our code
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# shellcheck source=/dev/null
+source "$(dirname "$0")/utils.sh"
+
+# cd to the root path
+REPO_PATH=$(get_root_path)
+
+# create a temporary directory
+TMP_DIR=$(mktemp -d)
+
+# cleanup
+exitHandler() (
+  echo "Cleaning up..."
+  rm -rf "${TMP_DIR}"
+)
+trap exitHandler EXIT
+
+# pull the source code and build the binary
+cd "${TMP_DIR}"
+URL="http://github.com/golang/lint"
+echo "Cloning ${URL} in ${TMP_DIR}..."
+git clone --quiet --depth=1 "${URL}" .
+echo "Building golint..."
+export GO111MODULE=on
+go build -o ./golint/golint ./golint
+
+# run the binary
+cd "${REPO_PATH}"
+echo "Running golint..."
+git ls-files | grep "\.go" | \
+  grep -v "vendor\/" | \
+  xargs -L1 "${TMP_DIR}/golint/golint" -set_exit_status

--- a/hack/verify-gotest.sh
+++ b/hack/verify-gotest.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# shellcheck source=/dev/null
+source "$(dirname "$0")/utils.sh"
+# cd to the root path
+cd_root_path
+
+# run go test
+export GO111MODULE=on
+ERROR=0
+DIRS=$(git ls-files | grep -v "vendor\/" | grep ".go" | xargs dirname | grep -v "\." | cut -d '/' -f 1 | uniq)
+while read -r dir; do
+    go test ./"$dir"/... || ERROR=1
+done <<< "$DIRS"
+
+if [[ "${ERROR}" = 1 ]]; then
+    echo "found errors in go test!"
+fi
+
+exit ${ERROR}

--- a/hack/verify-govet.sh
+++ b/hack/verify-govet.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# CI script to run go vet over our code
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# shellcheck source=/dev/null
+source "$(dirname "$0")/utils.sh"
+# cd to the root path
+cd_root_path
+
+# run go vet
+export GO111MODULE=on
+ERROR=0
+DIRS=$(git ls-files | grep -v "vendor\/" | grep ".go" | xargs dirname | grep -v "\." | cut -d '/' -f 1 | uniq)
+while read -r dir; do
+    go vet ./"$dir"/... || ERROR=1
+done <<< "$DIRS"
+
+if [[ "${ERROR}" = 1 ]]; then
+    echo "found errors in go vet!"
+fi
+
+exit ${ERROR}

--- a/hack/verify-shellcheck.sh
+++ b/hack/verify-shellcheck.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# set -o errexit
+set -o nounset
+set -o pipefail
+
+# shellcheck source=/dev/null
+source "$(dirname "$0")/utils.sh"
+ROOT_PATH=$(get_root_path)
+
+# create a temporary directory
+TMP_DIR=$(mktemp -d)
+
+# cleanup on exit
+cleanup() {
+  echo "Cleaning up..."
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+# install shellcheck (Linux-x64 only!)
+cd "${TMP_DIR}" || exit
+VERSION="shellcheck-v0.6.0"
+DOWNLOAD_FILE="${VERSION}.linux.x86_64.tar.xz"
+wget https://storage.googleapis.com/shellcheck/"${DOWNLOAD_FILE}"
+tar xf "${DOWNLOAD_FILE}"
+cd "${VERSION}" || exit
+
+echo "Running shellcheck..."
+cd "${ROOT_PATH}" || exit
+OUT="${TMP_DIR}/out.log"
+FILES=$(git ls-files | grep -v "vendor\/" | grep ".sh")
+while read -r file; do
+    "${TMP_DIR}/${VERSION}/shellcheck" "$file" >> "${OUT}" 2>&1
+done <<< "$FILES"
+
+if [[ -s "${OUT}" ]]; then
+  echo "Found errors:"
+  cat "${OUT}"
+  exit 1
+fi

--- a/hack/verify-spelling.sh
+++ b/hack/verify-spelling.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# shellcheck source=/dev/null
+source "$(dirname "$0")/utils.sh"
+# cd to the root path
+cd_root_path
+
+# create a temporary directory
+TMP_DIR=$(mktemp -d)
+
+# cleanup
+exitHandler() (
+  echo "Cleaning up..."
+  rm -rf "${TMP_DIR}"
+)
+trap exitHandler EXIT
+
+# pull misspell
+export GO111MODULE=on
+URL="https://github.com/client9/misspell"
+echo "Cloning ${URL} in ${TMP_DIR}..."
+git clone --quiet --depth=1 "${URL}" "${TMP_DIR}"
+pushd "${TMP_DIR}" > /dev/null
+go mod init
+popd > /dev/null
+
+# build misspell
+BIN_PATH="${TMP_DIR}/cmd/misspell"
+pushd "${BIN_PATH}" > /dev/null
+echo "Building misspell..."
+go build > /dev/null
+popd > /dev/null
+
+# check spelling
+RES=0
+ERROR_LOG="${TMP_DIR}/errors.log"
+echo "Checking spelling..."
+git ls-files | grep -v -e vendor | xargs "${BIN_PATH}/misspell" > "${ERROR_LOG}"
+if [[ -s "${ERROR_LOG}" ]]; then
+  sed 's/^/error: /' "${ERROR_LOG}" # add 'error' to each line to highlight in e2e status
+  echo "Found spelling errors!"
+  RES=1
+fi
+exit "${RES}"

--- a/hack/verify-staticcheck.sh
+++ b/hack/verify-staticcheck.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# CI script to run staticcheck
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# shellcheck source=/dev/null
+source "$(dirname "$0")/utils.sh"
+
+# cd to the root path
+REPO_PATH=$(get_root_path)
+
+# create a temporary directory
+TMP_DIR=$(mktemp -d)
+
+# cleanup
+exitHandler() (
+  echo "Cleaning up..."
+  rm -rf "${TMP_DIR}"
+)
+trap exitHandler EXIT
+
+# pull the source code and build the binary
+cd "${TMP_DIR}"
+URL="http://github.com/dominikh/go-tools"
+echo "Cloning ${URL} in ${TMP_DIR}..."
+git clone --quiet --depth=1 "${URL}" .
+echo "Building staticcheck..."
+export GO111MODULE=on
+go build -o ./bin/staticheck ./cmd/staticcheck
+
+# run the binary
+cd "${REPO_PATH}"
+echo "Running staticcheck..."
+"${TMP_DIR}/bin/staticheck" ./...

--- a/hack/verify-whitespace.sh
+++ b/hack/verify-whitespace.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o nounset
+set -o pipefail
+
+# shellcheck source=/dev/null
+source "$(dirname "$0")/utils.sh"
+# cd to the root path
+cd_root_path
+
+echo "Verifying trailing whitespace..."
+TRAILING="$(grep -rnI '[[:blank:]]$' . | grep -v -e "\.git" -v -e "vendor\/" -v -e "\.svg")"
+
+ERR="0"
+if [[ ! -z "$TRAILING" ]]; then
+    echo "Found trailing whitespace in the follow files:"
+    echo "${TRAILING}"
+    ERR="1"
+fi
+
+echo -e "Verifying new lines at end of files..."
+FILES="$(git ls-files | grep -I -v -e "vendor\/" -v -e "\.svg")"
+while read -r LINE; do
+    grep -qI . "${LINE}" || continue # skip binary files
+    c="$(tail -c 1 "${LINE}")"
+    if [[ "$c" != "" ]]; then
+        echo "${LINE}: no newline at the end of file"
+        ERR=1
+    fi
+done <<< "${FILES}"
+
+if [[ "$ERR" == "1" ]]; then
+    echo "Found whitespace errors!"
+    exit 1
+fi


### PR DESCRIPTION
this is copy-paste of the ~k/kubeadm/kinder~ k-sigs/etcdadm/hack scripts with minor modifications.
TODO add test-infra integration.
