### PR TITLE
fix misspell build for go 1.13

### DIFF
--- a/hack/verify-spelling.sh
+++ b/hack/verify-spelling.sh
@@ -38,7 +38,7 @@ URL="https://github.com/client9/misspell"
 echo "Cloning ${URL} in ${TMP_DIR}..."
 git clone --quiet --depth=1 "${URL}" "${TMP_DIR}"
 pushd "${TMP_DIR}" > /dev/null
-go mod init
+go mod init misspell
 popd > /dev/null
 
 # build misspell


### PR DESCRIPTION
this was overlooked for go 1.12 and broke when we started using 1.13.

/kind bug
/priority important-soon
/assign @yastij 