### PR TITLE
bump docker engine version to sync with k/k

### DIFF
--- a/validators/docker_validator.go
+++ b/validators/docker_validator.go
@@ -46,7 +46,7 @@ func (d *DockerValidator) Name() string {
 
 const (
 	dockerConfigPrefix           = "DOCKER_"
-	latestValidatedDockerVersion = "18.09"
+	latestValidatedDockerVersion = "19.03"
 )
 
 // Validate is part of the system.Validator interface.

--- a/validators/docker_validator_test.go
+++ b/validators/docker_validator_test.go
@@ -28,7 +28,7 @@ func TestValidateDockerInfo(t *testing.T) {
 		Reporter: DefaultReporter,
 	}
 	spec := &DockerSpec{
-		Version:     []string{`1\.13\..*`, `17\.0[3,6,9]\..*`, `18\.0[6,9]\..*`},
+		Version:     []string{`1\.13\..*`, `17\.0[3,6,9]\..*`, `18\.0[6,9]\..*`, `19\.03\..*`},
 		GraphDriver: []string{"driver_1", "driver_2"},
 	}
 	for _, test := range []struct {
@@ -86,8 +86,14 @@ func TestValidateDockerInfo(t *testing.T) {
 			warn: false,
 		},
 		{
-			name: "Docker version 19.01.0 is not in the list of validated versions",
-			info: dockerInfo{Driver: "driver_2", ServerVersion: "19.01.0"},
+			name: "valid Docker version 19.03.1-ce",
+			info: dockerInfo{Driver: "driver_2", ServerVersion: "19.03.1-ce"},
+			err:  false,
+			warn: false,
+		},
+		{
+			name: "Docker version 19.06.0 is not in the list of validated versions",
+			info: dockerInfo{Driver: "driver_2", ServerVersion: "19.06.0"},
 			err:  false,
 			warn: true,
 		},


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>

we diverged from k/k, this PR sync this repo with k/k and unblocks https://github.com/kubernetes/kubernetes/pull/84718

/assign @neolit123 