### PR TITLE
Update go version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/system-validators
 
-go 1.12
+go 1.13
 
 require (
 	github.com/blang/semver v3.5.0+incompatible


### PR DESCRIPTION
We now use go 1.13 and not 1.12

ref. https://github.com/kubernetes/kubernetes/pull/86269