### PR TITLE
Clarify dependency hack

### DIFF
--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -13,8 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-# Runs go mod tidy, go mod vendor, and then prun vendor
+# Runs go mod tidy
 #
 # Usage:
 #   update-deps.sh
@@ -27,21 +26,6 @@ set -o pipefail
 source "$(dirname "$0")/utils.sh"
 # cd to the root path
 cd_root_path
-
-prune-vendor() {
-  find vendor -type f \
-    -not -iname "*.c" \
-    -not -iname "*.go" \
-    -not -iname "*.h" \
-    -not -iname "*.proto" \
-    -not -iname "*.s" \
-    -not -iname "AUTHORS*" \
-    -not -iname "CONTRIBUTORS*" \
-    -not -iname "COPYING*" \
-    -not -iname "LICENSE*" \
-    -not -iname "NOTICE*" \
-    -exec rm '{}' \;
-}
 
 export GO111MODULE="on"
 go mod tidy


### PR DESCRIPTION
We don't vendor deps, so we should not say we do.

We do vendor deps in k/k, but a lot of the small side repos
(like k/test-infra) have stopped vendoring deps. Since we didn't do it from the beginning here,
I suggest that we don't do it, and remove the vendor related code (done in this PR).