### PR TITLE
Add preflight check for optional cgroups

### DIFF
--- a/validators/cgroup_validator_test.go
+++ b/validators/cgroup_validator_test.go
@@ -26,40 +26,40 @@ func TestValidateCgroupSubsystem(t *testing.T) {
 	v := &CgroupsValidator{
 		Reporter: DefaultReporter,
 	}
-	cgroupSpec := []string{"system1", "system2"}
 	for desc, test := range map[string]struct {
 		subsystems []string
+		cgroupSpec []string
 		required   bool
-		err        bool
+		missing    []string
 	}{
-		"missing required cgroup subsystem should report error": {
+		"missing required cgroup subsystem should report missing": {
+			cgroupSpec: []string{"system1", "system2"},
 			subsystems: []string{"system1"},
 			required:   true,
-			err:        true,
+			missing:    []string{"system2"},
 		},
-		"missing optional cgroup subsystem should report error": {
+		"missing optional cgroup subsystem should report missing": {
+			cgroupSpec: []string{"system1", "system2"},
 			subsystems: []string{"system1"},
 			required:   false,
-			err:        true,
+			missing:    []string{"system2"},
 		},
-		"extra cgroup subsystems should not report error": {
+		"extra cgroup subsystems should not report missing": {
+			cgroupSpec: []string{"system1", "system2"},
 			subsystems: []string{"system1", "system2", "system3"},
 			required:   true,
-			err:        false,
+			missing:    nil,
 		},
-		"subsystems the same with spec should not report error": {
+		"subsystems the same with spec should not report missing": {
+			cgroupSpec: []string{"system1"},
 			subsystems: []string{"system1", "system2"},
 			required:   false,
-			err:        false,
+			missing:    nil,
 		},
 	} {
 		t.Run(desc, func(t *testing.T) {
-			err := v.validateCgroupSubsystems(cgroupSpec, test.subsystems, test.required)
-			if !test.err {
-				assert.Nil(t, err, "%q: Expect error not to occur with cgroup", desc)
-			} else {
-				assert.NotNil(t, err, "%q: Expect error to occur with cgroup", desc)
-			}
+			missing := v.validateCgroupSubsystems(test.cgroupSpec, test.subsystems, test.required)
+			assert.Equal(t, test.missing, missing, "%q: Expect error not to occur with cgroup", desc)
 		})
 	}
 }

--- a/validators/cgroup_validator_test.go
+++ b/validators/cgroup_validator_test.go
@@ -29,27 +29,36 @@ func TestValidateCgroupSubsystem(t *testing.T) {
 	cgroupSpec := []string{"system1", "system2"}
 	for desc, test := range map[string]struct {
 		subsystems []string
+		required   bool
 		err        bool
 	}{
-		"missing cgroup subsystem should report error": {
+		"missing required cgroup subsystem should report error": {
 			subsystems: []string{"system1"},
+			required:   true,
+			err:        true,
+		},
+		"missing optional cgroup subsystem should report error": {
+			subsystems: []string{"system1"},
+			required:   false,
 			err:        true,
 		},
 		"extra cgroup subsystems should not report error": {
 			subsystems: []string{"system1", "system2", "system3"},
+			required:   true,
 			err:        false,
 		},
 		"subsystems the same with spec should not report error": {
 			subsystems: []string{"system1", "system2"},
+			required:   false,
 			err:        false,
 		},
 	} {
 		t.Run(desc, func(t *testing.T) {
-			err := v.validateCgroupSubsystems(cgroupSpec, test.subsystems)
+			err := v.validateCgroupSubsystems(cgroupSpec, test.subsystems, test.required)
 			if !test.err {
 				assert.Nil(t, err, "%q: Expect error not to occur with cgroup", desc)
 			} else {
-				assert.NotNil(t, err, "%q: Expect error to occur with docker info", desc)
+				assert.NotNil(t, err, "%q: Expect error to occur with cgroup", desc)
 			}
 		})
 	}

--- a/validators/types.go
+++ b/validators/types.go
@@ -53,6 +53,14 @@ type KernelSpec struct {
 	Forbidden []KernelConfig `json:"forbidden,omitempty"`
 }
 
+// CgroupSpec defines the specification for cgroups.
+type CgroupSpec struct {
+	// Required contains all required cgroups
+	Required []string `json:"required,omitempty"`
+	// Optional contains all optional cgroups
+	Optional []string `json:"optional,omitempty"`
+}
+
 // DockerSpec defines the requirement configuration for docker. Currently, it only
 // contains spec for graph driver.
 type DockerSpec struct {
@@ -113,7 +121,7 @@ type SysSpec struct {
 	// KernelConfig defines the spec for kernel.
 	KernelSpec KernelSpec `json:"kernelSpec,omitempty"`
 	// Cgroups is the required cgroups.
-	Cgroups []string `json:"cgroups,omitempty"`
+	CgroupSpec CgroupSpec `json:"cgroupSpec,omitempty"`
 	// RuntimeSpec defines the spec for runtime.
 	RuntimeSpec RuntimeSpec `json:"runtimeSpec,omitempty"`
 	// PackageSpec defines the required packages and their versions.

--- a/validators/types_unix.go
+++ b/validators/types_unix.go
@@ -56,7 +56,17 @@ var DefaultSysSpec = SysSpec{
 		},
 		Forbidden: []KernelConfig{},
 	},
-	Cgroups: []string{"cpu", "cpuacct", "cpuset", "devices", "freezer", "memory"},
+	CgroupSpec: CgroupSpec{
+		Required: []string{"cpu", "cpuacct", "cpuset", "devices", "freezer", "memory"},
+		Optional: []string{
+			// The hugetlb cgroup is optional since some kernels are compiled without support for huge pages
+			// and therefore lacks corresponding hugetlb cgroup
+			"hugetlb",
+			// The pids cgroup is optional since it is only used when at least one of the feature flags "SupportPodPidsLimit" and
+			// "SupportNodePidsLimit" is enabled
+			"pids",
+		},
+	},
 	RuntimeSpec: RuntimeSpec{
 		DockerSpec: &DockerSpec{
 			Version:     []string{`1\.1[1-3]\..*`, `17\.0[3,6,9]\..*`, `18\.0[6,9]\..*`, `19\.03\..*`},


### PR DESCRIPTION
pids and hugetlb are optional, ref.
https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/cm/cgroup_manager_linux.go#L325