### PR TITLE
Support for cgroupv2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,5 @@ require (
 	github.com/blang/semver v3.5.0+incompatible
 	github.com/pkg/errors v0.8.0
 	github.com/stretchr/testify v1.3.0
+	golang.org/x/sys v0.0.0-20191022100944-742c48ecaeb7
 )

--- a/go.sum
+++ b/go.sum
@@ -9,3 +9,5 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+golang.org/x/sys v0.0.0-20191022100944-742c48ecaeb7 h1:HmbHVPwrPEKPGLAcHSrMe6+hqSUlvZU0rab6x5EXfGU=
+golang.org/x/sys v0.0.0-20191022100944-742c48ecaeb7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/validators/cgroup_validator_test.go
+++ b/validators/cgroup_validator_test.go
@@ -23,6 +23,9 @@ import (
 )
 
 func TestValidateCgroupSubsystem(t *testing.T) {
+	// hardcoded cgroup v2 subsystems
+	pseudoSubsystems := []string{"devices", "freezer"}
+
 	v := &CgroupsValidator{
 		Reporter: DefaultReporter,
 	}
@@ -53,6 +56,30 @@ func TestValidateCgroupSubsystem(t *testing.T) {
 		"subsystems the same with spec should not report missing": {
 			cgroupSpec: []string{"system1"},
 			subsystems: []string{"system1", "system2"},
+			required:   false,
+			missing:    nil,
+		},
+		"missing required cgroup subsystem when pseudo hardcoded subsystems are set": {
+			cgroupSpec: []string{"system1", "devices", "freezer"},
+			subsystems: append(pseudoSubsystems),
+			required:   true,
+			missing:    []string{"system1"},
+		},
+		"missing optional cgroup subsystem when pseudo hardcoded subsystems are set": {
+			cgroupSpec: []string{"system1", "devices", "freezer"},
+			subsystems: append(pseudoSubsystems),
+			required:   false,
+			missing:    []string{"system1"},
+		},
+		"extra cgroup subsystems when pseudo hardcoded subsystems are set": {
+			cgroupSpec: []string{"system1", "devices", "freezer"},
+			subsystems: append(pseudoSubsystems, "system1", "system2"),
+			required:   true,
+			missing:    nil,
+		},
+		"matching list of cgroup subsystems including pseudo hardcoded subsystems": {
+			cgroupSpec: []string{"system1", "devices", "freezer"},
+			subsystems: append(pseudoSubsystems, "system1"),
 			required:   false,
 			missing:    nil,
 		},

--- a/validators/types.go
+++ b/validators/types.go
@@ -120,8 +120,10 @@ type SysSpec struct {
 	OS string `json:"os,omitempty"`
 	// KernelConfig defines the spec for kernel.
 	KernelSpec KernelSpec `json:"kernelSpec,omitempty"`
-	// Cgroups is the required cgroups.
+	// Cgroups is the required cgroups v1.
 	CgroupSpec CgroupSpec `json:"cgroupSpec,omitempty"`
+	// Cgroups is the required cgroups v2.
+	CgroupV2Spec CgroupSpec `json:"cgroupV2Spec,omitempty"`
 	// RuntimeSpec defines the spec for runtime.
 	RuntimeSpec RuntimeSpec `json:"runtimeSpec,omitempty"`
 	// PackageSpec defines the required packages and their versions.

--- a/validators/types_unix.go
+++ b/validators/types_unix.go
@@ -67,6 +67,10 @@ var DefaultSysSpec = SysSpec{
 			"pids",
 		},
 	},
+	CgroupV2Spec: CgroupSpec{
+		Required: []string{"cpu", "cpuset", "devices", "freezer", "memory"},
+		Optional: []string{"hugetlb", "pids"},
+	},
 	RuntimeSpec: RuntimeSpec{
 		DockerSpec: &DockerSpec{
 			Version:     []string{`1\.1[1-3]\..*`, `17\.0[3,6,9]\..*`, `18\.0[6,9]\..*`, `19\.03\..*`},


### PR DESCRIPTION
Preflight check will fail when clusters use cgroupv2 in future because /proc/cgroups is meaningless for v2.