### PR TITLE
properly perform build verification and skip some tests on non-Linux

### DIFF
--- a/hack/verify-govet.sh
+++ b/hack/verify-govet.sh
@@ -28,7 +28,9 @@ export GO111MODULE=on
 ERROR=0
 DIRS=$(git ls-files | grep -v "vendor\/" | grep ".go" | xargs dirname | grep -v "\." | cut -d '/' -f 1 | uniq)
 while read -r dir; do
-    go vet ./"$dir"/... || ERROR=1
+    for os in {darwin,linux,windows}; do
+        GOOS=$os go vet ./"$dir"/... || ERROR=1
+    done
 done <<< "$DIRS"
 
 if [[ "${ERROR}" = 1 ]]; then

--- a/validators/cgroup_validator_linux.go
+++ b/validators/cgroup_validator_linux.go
@@ -1,3 +1,5 @@
+// +build linux
+
 /*
 Copyright 2016 The Kubernetes Authors.
 

--- a/validators/cgroup_validator_other.go
+++ b/validators/cgroup_validator_other.go
@@ -1,0 +1,38 @@
+// +build !linux
+
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package system
+
+// NOOP for non-Linux OSes.
+
+var _ Validator = &CgroupsValidator{}
+
+// CgroupsValidator validates cgroup configuration.
+type CgroupsValidator struct {
+	Reporter Reporter
+}
+
+// Validate is part of the system.Validator interface.
+func (c *CgroupsValidator) Validate(spec SysSpec) (warns, errs []error) {
+	return
+}
+
+// Name is part of the system.Validator interface.
+func (c *CgroupsValidator) Name() string {
+	return "cgroups"
+}

--- a/validators/cgroup_validator_test.go
+++ b/validators/cgroup_validator_test.go
@@ -1,3 +1,5 @@
+// +build linux
+
 /*
 Copyright 2016 The Kubernetes Authors.
 

--- a/validators/package_validator_linux.go
+++ b/validators/package_validator_linux.go
@@ -1,3 +1,5 @@
+// +build linux
+
 /*
 Copyright 2017 The Kubernetes Authors.
 

--- a/validators/package_validator_other.go
+++ b/validators/package_validator_other.go
@@ -1,0 +1,38 @@
+// +build !linux
+
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package system
+
+// NOOP for non-Linux OSes.
+
+// packageValidator implements the Validator interface. It validates packages
+// and their versions.
+type packageValidator struct {
+	reporter Reporter
+}
+
+// Name returns the name of the package validator.
+func (validator *packageValidator) Name() string {
+	return "package"
+}
+
+// Validate checks packages and their versions against the packageSpecs using
+// the packageManager, and returns an error on any package/version mismatch.
+func (validator *packageValidator) Validate(spec SysSpec) ([]error, []error) {
+	return nil, nil
+}

--- a/validators/package_validator_test.go
+++ b/validators/package_validator_test.go
@@ -1,3 +1,5 @@
+// +build linux
+
 /*
 Copyright 2017 The Kubernetes Authors.
 

--- a/validators/types_windows.go
+++ b/validators/types_windows.go
@@ -32,7 +32,6 @@ var DefaultSysSpec = SysSpec{
 		Optional:  []KernelConfig{},
 		Forbidden: []KernelConfig{},
 	},
-	Cgroups: []string{},
 	RuntimeSpec: RuntimeSpec{
 		DockerSpec: &DockerSpec{
 			Version:     []string{`18\.0[6,9]\..*`},


### PR DESCRIPTION
fix issues that blocked this PR from merging in k/k:
https://github.com/kubernetes/kubernetes/pull/89901

contains 4 commits:

```
cgroup_validator: don't validate cgroups on non-Linux
package_validator: don't validate packages on non-Linux
```
[this PR](https://github.com/kubernetes/system-validators/pull/12/files) added a `golang.org/x/sys/unix` import, but `unix.CGROUP2_SUPER_MAGIC` is not defined on `windows`.
cgroup and package validation only makes sense on Linux, thus split the files and no-op the cgroup and package validation for `!linux`. package validation could be extended one day to support other OSes and package managers, but might be a better idea to remove this code instead..

---

`ValidateSpec: don't include cgroups and package validators on non-Linux`

running cgroup and package validation does not make sense for non-Linux OSes.

---

`hack: run govet for all supported OS-es (darwin,linux,windows) `

This will catch compile time problems not only for the host OS
where the verification is being run.

---
