### PR TITLE
revert the introduction of CgroupSpec

### DIFF
--- a/validators/cgroup_validator_linux.go
+++ b/validators/cgroup_validator_linux.go
@@ -64,15 +64,15 @@ func (c *CgroupsValidator) Validate(spec SysSpec) (warns, errs []error) {
 		if err != nil {
 			return nil, []error{errors.Wrap(err, "failed to get cgroup v2 subsystems")}
 		}
-		requiredCgroupSpec = spec.CgroupV2Spec.Required
-		optionalCgroupSpec = spec.CgroupV2Spec.Optional
+		requiredCgroupSpec = spec.CgroupsV2
+		optionalCgroupSpec = spec.CgroupsV2Optional
 	} else {
 		subsystems, err = c.getCgroupV1Subsystems()
 		if err != nil {
 			return nil, []error{errors.Wrap(err, "failed to get cgroup v1 subsystems")}
 		}
-		requiredCgroupSpec = spec.CgroupSpec.Required
-		optionalCgroupSpec = spec.CgroupSpec.Optional
+		requiredCgroupSpec = spec.Cgroups
+		optionalCgroupSpec = spec.CgroupsOptional
 	}
 
 	if missingRequired := c.validateCgroupSubsystems(requiredCgroupSpec, subsystems, true); len(missingRequired) != 0 {

--- a/validators/types.go
+++ b/validators/types.go
@@ -53,14 +53,6 @@ type KernelSpec struct {
 	Forbidden []KernelConfig `json:"forbidden,omitempty"`
 }
 
-// CgroupSpec defines the specification for cgroups.
-type CgroupSpec struct {
-	// Required contains all required cgroups
-	Required []string `json:"required,omitempty"`
-	// Optional contains all optional cgroups
-	Optional []string `json:"optional,omitempty"`
-}
-
 // DockerSpec defines the requirement configuration for docker. Currently, it only
 // contains spec for graph driver.
 type DockerSpec struct {
@@ -120,10 +112,16 @@ type SysSpec struct {
 	OS string `json:"os,omitempty"`
 	// KernelConfig defines the spec for kernel.
 	KernelSpec KernelSpec `json:"kernelSpec,omitempty"`
-	// Cgroups is the required cgroups v1.
-	CgroupSpec CgroupSpec `json:"cgroupSpec,omitempty"`
-	// Cgroups is the required cgroups v2.
-	CgroupV2Spec CgroupSpec `json:"cgroupV2Spec,omitempty"`
+
+	// Cgroups is the required cgroups.
+	Cgroups []string `json:"cgroups,omitempty"`
+	// CgroupsOptional is the optional cgroups.
+	CgroupsOptional []string `json:"cgroupsOptional,omitempty"`
+	// CgroupsV2 is the required cgroups v2.
+	CgroupsV2 []string `json:"cgroupsV2,omitempty"`
+	// CgroupsV2Optional is the optional cgroups v2.
+	CgroupsV2Optional []string `json:"cgroupsV2Optional,omitempty"`
+
 	// RuntimeSpec defines the spec for runtime.
 	RuntimeSpec RuntimeSpec `json:"runtimeSpec,omitempty"`
 	// PackageSpec defines the required packages and their versions.

--- a/validators/types_unix.go
+++ b/validators/types_unix.go
@@ -56,21 +56,17 @@ var DefaultSysSpec = SysSpec{
 		},
 		Forbidden: []KernelConfig{},
 	},
-	CgroupSpec: CgroupSpec{
-		Required: []string{"cpu", "cpuacct", "cpuset", "devices", "freezer", "memory"},
-		Optional: []string{
-			// The hugetlb cgroup is optional since some kernels are compiled without support for huge pages
-			// and therefore lacks corresponding hugetlb cgroup
-			"hugetlb",
-			// The pids cgroup is optional since it is only used when at least one of the feature flags "SupportPodPidsLimit" and
-			// "SupportNodePidsLimit" is enabled
-			"pids",
-		},
+	Cgroups: []string{"cpu", "cpuacct", "cpuset", "devices", "freezer", "memory"},
+	CgroupsOptional: []string{
+		// The hugetlb cgroup is optional since some kernels are compiled without support for huge pages
+		// and therefore lacks corresponding hugetlb cgroup
+		"hugetlb",
+		// The pids cgroup is optional since it is only used when at least one of the feature flags "SupportPodPidsLimit" and
+		// "SupportNodePidsLimit" is enabled
+		"pids",
 	},
-	CgroupV2Spec: CgroupSpec{
-		Required: []string{"cpu", "cpuset", "devices", "freezer", "memory"},
-		Optional: []string{"hugetlb", "pids"},
-	},
+	CgroupsV2:         []string{"cpu", "cpuset", "devices", "freezer", "memory"},
+	CgroupsV2Optional: []string{"hugetlb", "pids"},
 	RuntimeSpec: RuntimeSpec{
 		DockerSpec: &DockerSpec{
 			Version:     []string{`1\.1[1-3]\..*`, `17\.0[3,6,9]\..*`, `18\.0[6,9]\..*`, `19\.03\..*`},


### PR DESCRIPTION
This change broke the backwards compatibility with the old SysSpec
"API". To workaround the issue without introducing a v2.0.0 release
use separate optional []string fields - e.g. CgroupsOptional,
CgroupsV2Optional.

/kind bug
/priority important-soon
/assign @liggitt 
