### PR TITLE
update OWNERS.md and add release guide in README.md

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,9 +1,17 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - luxas
-  - timothysc
-  - fabriziopandini
-  - neolit123
-  - rosti
-  - ereslibre
+- fabriziopandini
+- neolit123
+- SataQiu
+reviewers:
+- KentaTada
+- odinuge
+emeritus_approvers:
+- luxas
+- timothysc
+- rosti
+- ereslibre
+labels:
+- sig/cluster-lifecycle
+- sig/node

--- a/README.md
+++ b/README.md
@@ -2,6 +2,27 @@
 
 A set of system-oriented validators for kubeadm preflight checks.
 
+## Creating releases
+
+To prepare a release of this library please follow this guide:
+- The main branch should always contain WIP commits planned for the upcoming release.
+- Always create a new branch for MAJOR and MINOR releases. This allows backporting changes.
+- Release branch names should be in the format `release-MAJOR.MINOR` (without a `v` prefix).
+- Only non-breaking bug fixes can be done in a PATCH release.
+- New features must not be added in PATCH releases.
+- Breaking changes must be added in a MAJOR release.
+- Pushing releases requires write access. To obtain that you must be part of
+the [`system-validator-maintainers` team](http://git.k8s.io/org/config/kubernetes/sig-cluster-lifecycle/teams.yaml).
+
+For vendoring the new release in kubernetes/kubernetes you can use its `pin-dependency.sh` script.
+
+Example:
+```bash
+./hack/pin-dependency.sh k8s.io/system-validators <NEW-TAG>
+```
+
+And then PR the changes.
+
 ## Community, discussion, contribution, and support
 
 Learn how to engage with the Kubernetes community on the [community page](http://kubernetes.io/community/).


### PR DESCRIPTION
first commit is an OWNERS update:
- @KentaTada @odinuge as reviewers. thanks for your contributions!
- @SataQiu as approver

remove approvers to sync with https://github.com/kubernetes/kubernetes/pull/98547
- @luxas, @timothysc, @rosti, @ereslibre 

please state if you object to these changes.
applying lazy consensus next week ~4th of Feb.

@KentaTada i think you are not a member of the kubernetes github org?
if so, i'd be happy to sponsor your membership. likely @odinuge can +1 as well.

https://github.com/kubernetes/community/blob/master/community-membership.md#requirements
it requires sending a PR to k/org.

second commit adds a small release guide to README.md.
