### PR TITLE
docker_validator: allow Docker 20.10.*

### DIFF
--- a/validators/docker_validator.go
+++ b/validators/docker_validator.go
@@ -49,7 +49,7 @@ func (d *DockerValidator) Name() string {
 
 const (
 	dockerConfigPrefix           = "DOCKER_"
-	latestValidatedDockerVersion = "19.03"
+	latestValidatedDockerVersion = "20.10"
 )
 
 // Validate is part of the system.Validator interface.

--- a/validators/docker_validator_test.go
+++ b/validators/docker_validator_test.go
@@ -28,7 +28,7 @@ func TestValidateDockerInfo(t *testing.T) {
 		Reporter: DefaultReporter,
 	}
 	spec := &DockerSpec{
-		Version:     []string{`1\.13\..*`, `17\.0[3,6,9]\..*`, `18\.0[6,9]\..*`, `19\.03\..*`},
+		Version:     []string{`1\.13\..*`, `17\.0[3,6,9]\..*`, `18\.0[6,9]\..*`, `19\.03\..*`, `20\.10\..*`},
 		GraphDriver: []string{"driver_1", "driver_2"},
 	}
 	for _, test := range []struct {
@@ -96,6 +96,12 @@ func TestValidateDockerInfo(t *testing.T) {
 			info: dockerInfo{Driver: "driver_2", ServerVersion: "19.06.0"},
 			err:  false,
 			warn: true,
+		},
+		{
+			name: "valid Docker version 20.10.3",
+			info: dockerInfo{Driver: "driver_2", ServerVersion: "20.10.3"},
+			err:  false,
+			warn: false,
 		},
 		{
 			name: "Docker daemon not available",

--- a/validators/types_unix.go
+++ b/validators/types_unix.go
@@ -70,7 +70,7 @@ var DefaultSysSpec = SysSpec{
 	CgroupsV2Optional: []string{"hugetlb"},
 	RuntimeSpec: RuntimeSpec{
 		DockerSpec: &DockerSpec{
-			Version:     []string{`1\.1[1-3]\..*`, `17\.0[3,6,9]\..*`, `18\.0[6,9]\..*`, `19\.03\..*`},
+			Version:     []string{`1\.1[1-3]\..*`, `17\.0[3,6,9]\..*`, `18\.0[6,9]\..*`, `19\.03\..*`, `20\.10\..*`},
 			GraphDriver: []string{"aufs", "overlay", "overlay2", "devicemapper", "zfs"},
 		},
 	},

--- a/validators/types_windows.go
+++ b/validators/types_windows.go
@@ -34,7 +34,7 @@ var DefaultSysSpec = SysSpec{
 	},
 	RuntimeSpec: RuntimeSpec{
 		DockerSpec: &DockerSpec{
-			Version:     []string{`18\.0[6,9]\..*`},
+			Version:     []string{`18\.0[6,9]\..*`, `19\.03\..*`},
 			GraphDriver: []string{"windowsfilter"},
 		},
 	},


### PR DESCRIPTION
For Windows keep the latest version to 19.03.* as this is what
"Install-WindowsFeature -Name containers" installs on latest
versions of Windows Server (e.g. 1909 from a 2021 build on GCE).

For Linux, projects like kops have been validating 20.10 for a while.

will update this in k/k for v1.21.
