### PR TITLE
hack/verify-spelling: add "go mod tidy"

### DIFF
--- a/hack/verify-spelling.sh
+++ b/hack/verify-spelling.sh
@@ -39,6 +39,7 @@ echo "Cloning ${URL} in ${TMP_DIR}..."
 git clone --quiet --depth=1 "${URL}" "${TMP_DIR}"
 pushd "${TMP_DIR}" > /dev/null
 go mod init misspell
+go mod tidy
 popd > /dev/null
 
 # build misspell


### PR DESCRIPTION
"go mod tidy" is required by go 1.16+ on new modules
to trigger the update to go.mod/sum.

without this, the verify check will fail on new PRs.
