### PR TITLE
Add preflight check for seccomp

### DIFF
--- a/validators/types_unix.go
+++ b/validators/types_unix.go
@@ -57,6 +57,8 @@ var DefaultSysSpec = SysSpec{
 			{Name: "BLK_DEV_DM", Description: "Required for devicemapper."},
 			{Name: "CFS_BANDWIDTH", Description: "Required for CPU quota."},
 			{Name: "CGROUP_HUGETLB", Description: "Required for hugetlb cgroup."},
+			{Name: "SECCOMP", Description: "Required for seccomp."},
+			{Name: "SECCOMP_FILTER", Description: "Required for seccomp mode 2."},
 		},
 		Forbidden: []KernelConfig{},
 	},


### PR DESCRIPTION
seccomp has already been GA since Kubernetes 1.19.
I think it is essential for the current Kubernetes, but could you give me your opinion if you have any concern about adding the seccomp check?

Signed-off-by: Kenta Tada <Kenta.Tada@sony.com>