### PR TITLE
Allow the Btrfs storage graph driver to be used

### DIFF
--- a/validators/types_unix.go
+++ b/validators/types_unix.go
@@ -73,7 +73,7 @@ var DefaultSysSpec = SysSpec{
 	RuntimeSpec: RuntimeSpec{
 		DockerSpec: &DockerSpec{
 			Version:     []string{`1\.1[1-3]\..*`, `17\.0[3,6,9]\..*`, `18\.0[6,9]\..*`, `19\.03\..*`, `20\.10\..*`},
-			GraphDriver: []string{"aufs", "overlay", "overlay2", "devicemapper", "zfs"},
+			GraphDriver: []string{"aufs", "btrfs", "overlay", "overlay2", "devicemapper", "zfs"},
 		},
 	},
 }


### PR DESCRIPTION
Btrfs is a fully functioning mainline graph driver supported by containerd and cri-o.