### PR TITLE
Add blkio for iops limit support in the future

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/system-validators
 
-go 1.13
+go 1.16
 
 require (
 	github.com/blang/semver v3.5.0+incompatible

--- a/validators/cgroup_validator_linux.go
+++ b/validators/cgroup_validator_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/validators/cgroup_validator_other.go
+++ b/validators/cgroup_validator_other.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 /*

--- a/validators/cgroup_validator_test.go
+++ b/validators/cgroup_validator_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/validators/package_validator_linux.go
+++ b/validators/package_validator_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/validators/package_validator_other.go
+++ b/validators/package_validator_other.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 /*

--- a/validators/package_validator_test.go
+++ b/validators/package_validator_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/validators/types_unix.go
+++ b/validators/types_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/validators/types_unix.go
+++ b/validators/types_unix.go
@@ -67,9 +67,12 @@ var DefaultSysSpec = SysSpec{
 		// The hugetlb cgroup is optional since some kernels are compiled without support for huge pages
 		// and therefore lacks corresponding hugetlb cgroup
 		"hugetlb",
+		// The blkio cgroup is optional since some kernels are compiled without support for block I/O throttling.
+		// Containerd and cri-o will use blkio to track disk I/O and throttling in both cgroup v1 and v2.
+		"blkio",
 	},
 	CgroupsV2:         []string{"cpu", "cpuset", "devices", "freezer", "memory", "pids"},
-	CgroupsV2Optional: []string{"hugetlb"},
+	CgroupsV2Optional: []string{"hugetlb", "blkio"},
 	RuntimeSpec: RuntimeSpec{
 		DockerSpec: &DockerSpec{
 			Version:     []string{`1\.1[1-3]\..*`, `17\.0[3,6,9]\..*`, `18\.0[6,9]\..*`, `19\.03\..*`, `20\.10\..*`},

--- a/validators/types_windows.go
+++ b/validators/types_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 /*


### PR DESCRIPTION
Fixes #28 

The support of iops in kubernetes and contained can be found and tracked in https://github.com/kubernetes/kubernetes/issues/92287#issuecomment-1010723587 and https://github.com/kubernetes/enhancements/pull/1907, https://github.com/containerd/containerd/pull/5490, https://github.com/cri-o/cri-o/pull/4873.