### PR TITLE
Use not "blkio" but "io" controller in cgroups v2

### DIFF
--- a/validators/types_unix.go
+++ b/validators/types_unix.go
@@ -72,8 +72,12 @@ var DefaultSysSpec = SysSpec{
 		// Containerd and cri-o will use blkio to track disk I/O and throttling in both cgroup v1 and v2.
 		"blkio",
 	},
-	CgroupsV2:         []string{"cpu", "cpuset", "devices", "freezer", "memory", "pids"},
-	CgroupsV2Optional: []string{"hugetlb", "blkio"},
+	CgroupsV2: []string{"cpu", "cpuset", "devices", "freezer", "memory", "pids"},
+	CgroupsV2Optional: []string{
+		"hugetlb",
+		// The cgroups v2 io controller is the successor of the v1 blkio controller.
+		"io",
+	},
 	RuntimeSpec: RuntimeSpec{
 		DockerSpec: &DockerSpec{
 			Version:     []string{`1\.1[1-3]\..*`, `17\.0[3,6,9]\..*`, `18\.0[6,9]\..*`, `19\.03\..*`, `20\.10\..*`},


### PR DESCRIPTION
"blkio" controller seems to be available only for cgroups v1 according to [man cgroups(7)](https://man7.org/linux/man-pages/man7/cgroups.7.html).

See also: https://github.com/kubernetes/system-validators/issues/31