### PR TITLE
kernel version should be 4.19+; recommend version 5.8 for cgroup v2

### DIFF
--- a/validators/kernel_validator.go
+++ b/validators/kernel_validator.go
@@ -90,7 +90,7 @@ func (k *KernelValidator) validateKernelVersion(kSpec KernelSpec) error {
 		}
 	}
 	k.Reporter.Report("KERNEL_VERSION", k.kernelRelease, bad)
-	return fmt.Errorf("unsupported kernel release: %s", k.kernelRelease)
+	return fmt.Errorf("kernel release %s is unsupported. %s", k.kernelRelease, kSpec.VersionsNote)
 }
 
 // validateKernelConfig validates the kernel configurations.

--- a/validators/kernel_validator_test.go
+++ b/validators/kernel_validator_test.go
@@ -31,20 +31,45 @@ func TestValidateKernelVersion(t *testing.T) {
 	// they may be different.
 	// This is fine, because the test mainly tests the kernel version validation logic,
 	// not the DefaultSysSpec. The DefaultSysSpec should be tested with node e2e.
-	testRegex := []string{`^3\.[1-9][0-9].*$`, `^([4-9]|[1-9][0-9]+)\.([0-9]+)\.([0-9]+).*$`}
+	testRegex := []string{`^4\.19.*$`, `^4\.[2-9][0-9].*$`, `^([5-9]|[1-9][0-9]+)\.([0-9]+)\.([0-9]+).*$`}
 	for _, test := range []struct {
 		name    string
 		version string
 		err     bool
 	}{
 		{
-			name:    "3.19.9-99-test first version regex matches",
+			name:    "3.19.9-99-test no version regex matches",
 			version: "3.19.9-99-test",
+			err:     true,
+		},
+		{
+			name:    "4.4.14+ no version regex matches",
+			version: "4.4.14+",
+			err:     true,
+		},
+		{
+			name:    "4.7.1 no version regex matches",
+			version: "4.7.1",
+			err:     true,
+		},
+		{
+			name:    "4.17.3 no version regex matches",
+			version: "4.17.3",
+			err:     true,
+		},
+		{
+			name:    "4.19.3-99-test matches",
+			version: "4.19.3-99-test",
 			err:     false,
 		},
 		{
-			name:    "4.4.14+ one of version regexes matches",
-			version: "4.4.14+",
+			name:    "4.20.3+ matches",
+			version: "4.20.3+",
+			err:     false,
+		},
+		{
+			name:    "5.12.3 matches",
+			version: "5.12.3",
 			err:     false,
 		},
 		{
@@ -79,7 +104,7 @@ func TestValidateKernelVersion(t *testing.T) {
 			if !test.err {
 				assert.Nil(t, err, "Expect error not to occur with kernel version %q", test.version)
 			} else {
-				assert.NotNil(t, err, "Expect error to occur with kenrel version %q", test.version)
+				assert.NotNil(t, err, "Expect error to occur with kernel version %q", test.version)
 			}
 		})
 	}
@@ -189,7 +214,7 @@ func TestValidateCachedKernelConfig(t *testing.T) {
 			if !test.err {
 				assert.Nil(t, err, "Expect error not to occur with kernel config %q", test.config)
 			} else {
-				assert.NotNil(t, err, "Expect error to occur with kenrel config %q", test.config)
+				assert.NotNil(t, err, "Expect error to occur with kernel config %q", test.config)
 			}
 		})
 	}

--- a/validators/types.go
+++ b/validators/types.go
@@ -42,6 +42,8 @@ type KernelConfig struct {
 type KernelSpec struct {
 	// Versions define supported kernel version. It is a group of regexps.
 	Versions []string `json:"versions,omitempty"`
+	// VersionsNote provides additional information if Versions do not match.
+	VersionsNote string `json:"versionsNote,omitempty"`
 	// Required contains all kernel configurations required to be enabled
 	// (built in or as module).
 	Required []KernelConfig `json:"required,omitempty"`

--- a/validators/types_unix.go
+++ b/validators/types_unix.go
@@ -28,7 +28,9 @@ import (
 var DefaultSysSpec = SysSpec{
 	OS: "Linux",
 	KernelSpec: KernelSpec{
-		Versions: []string{`^3\.[1-9][0-9].*$`, `^([4-9]|[1-9][0-9]+)\.([0-9]+)\.([0-9]+).*$`}, // Requires 3.10+, or newer
+		// 4.19 is an active kernel Long Term Support (LTS) release, tracked in https://www.kernel.org/category/releases.html.
+		Versions:     []string{`^4\.19.*$`, `^4\.[2-9][0-9].*$`, `^([5-9]|[1-9][0-9]+)\.([0-9]+)\.([0-9]+).*$`},
+		VersionsNote: "Recommended LTS version from the 4.x series is 4.19. Any 5.x or 6.x versions are also supported. For cgroups v2 support, the minimal version is 4.15 and the recommended version is 5.8+",
 		// TODO(random-liu): Add more config
 		// TODO(random-liu): Add description for each kernel configuration:
 		Required: []KernelConfig{

--- a/validators/types_windows.go
+++ b/validators/types_windows.go
@@ -28,10 +28,11 @@ import (
 var DefaultSysSpec = SysSpec{
 	OS: "Microsoft Windows Server 2016",
 	KernelSpec: KernelSpec{
-		Versions:  []string{`10\.0\.1439[3-9]`, `10\.0\.14[4-9][0-9]{2}`, `10\.0\.1[5-9][0-9]{3}`, `10\.0\.[2-9][0-9]{4}`, `10\.[1-9]+\.[0-9]+`}, //requires >= '10.0.14393'
-		Required:  []KernelConfig{},
-		Optional:  []KernelConfig{},
-		Forbidden: []KernelConfig{},
+		Versions:     []string{`10\.0\.1439[3-9]`, `10\.0\.14[4-9][0-9]{2}`, `10\.0\.1[5-9][0-9]{3}`, `10\.0\.[2-9][0-9]{4}`, `10\.[1-9]+\.[0-9]+`}, //requires >= '10.0.14393'
+		VersionsNote: "The kernel version should be >= '10.0.14393'",
+		Required:     []KernelConfig{},
+		Optional:     []KernelConfig{},
+		Forbidden:    []KernelConfig{},
 	},
 	RuntimeSpec: RuntimeSpec{
 		DockerSpec: &DockerSpec{


### PR DESCRIPTION
For kernel long term support, see https://wiki.linuxfoundation.org/civilinfrastructureplatform/start and https://endoflife.date/linux
-  4.4 & 4.19 are selected as kernel Super Long Term Support (SLTS), and the Civil Infrastructure Platform will provide support until at least 2026. 
   -  **EDITED removed 4.4** as CIP is not in https://www.kernel.org/category/releases.html and maintained in a different place.
- For [cgroup v2](https://kubernetes.io/docs/concepts/architecture/cgroups/), Kubernetes recommends to use 5.8 and later, and in runc docs, the minimal version is 4.15 and 5.2+ is recommended. 

Other comments that may be related:

> In Kubernetes 1.31, cgroup v1 is moved to maintenance mode and 4.14 LTS EOF in Jan 2024 (linux, LTS) , besides, centos 7 is EOL in June 30, 2024. I chosen 4.15 as runc.
> 
> - for kernel minimal version, choosing 4.15 as runc + cgroup v2 https://github.com/opencontainers/runc/blob/3778ae603c706494fd1e2c2faf83b406e38d687d/docs/cgroup-v2.md?plain=1#L24
>   - kernel >= 4.15 with CONFIG_CGROUP_DEVICE and CONFIG_CGROUP_BPF is required.  From https://github.com/containerd/containerd/pull/3799#issuecomment-555740694. 
>   - cpu (since Linux 4.15)
> - cgroup v2: Kubernetes recommended kernel version https://kubernetes.io/docs/concepts/architecture/cgroups/
> 
> More details can be found in https://github.com/kubernetes/kubernetes/issues/116799.
> 
> The v1.31 KEP https://github.com/kubernetes/enhancements/issues/4569
> -  https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/4569-cgroup-v1-maintenance-mode/README.md KEP-4569: Moving cgroup v1 support into maintenance mode 
> 
> Other minimal kernel version candidates
> - kernel 4.5 announced that cgroup v2 is not experimental anymore, as it supports io/pids/memory.
> - runc recommends 5.2+ as 5.2 supports freezer.
