### PR TITLE
add cgroup v1 warning as it is in maintaince mode for kube

### DIFF
--- a/validators/cgroup_validator_test.go
+++ b/validators/cgroup_validator_test.go
@@ -64,13 +64,13 @@ func TestValidateCgroupSubsystem(t *testing.T) {
 		},
 		"missing required cgroup subsystem when pseudo hardcoded subsystems are set": {
 			cgroupSpec: []string{"system1", "devices", "freezer"},
-			subsystems: append(pseudoSubsystems),
+			subsystems: pseudoSubsystems,
 			required:   true,
 			missing:    []string{"system1"},
 		},
 		"missing optional cgroup subsystem when pseudo hardcoded subsystems are set": {
 			cgroupSpec: []string{"system1", "devices", "freezer"},
-			subsystems: append(pseudoSubsystems),
+			subsystems: pseudoSubsystems,
 			required:   false,
 			missing:    []string{"system1"},
 		},


### PR DESCRIPTION
- add a warning if the node is cgroup v1

The v1.31 KEP https://github.com/kubernetes/enhancements/issues/4569
- https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/4569-cgroup-v1-maintenance-mode/README.md KEP-4569: Moving cgroup v1 support into maintenance mode