### PR TITLE
check unified Mountpoint cgroup version in case user uses cgroupoup v1 on new kernel

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,4 @@ go 1.16
 require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/stretchr/testify v1.3.0
-	golang.org/x/sys v0.0.0-20191022100944-742c48ecaeb7
 )

--- a/go.sum
+++ b/go.sum
@@ -7,5 +7,3 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-golang.org/x/sys v0.0.0-20191022100944-742c48ecaeb7 h1:HmbHVPwrPEKPGLAcHSrMe6+hqSUlvZU0rab6x5EXfGU=
-golang.org/x/sys v0.0.0-20191022100944-742c48ecaeb7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/validators/cgroup_validator_linux.go
+++ b/validators/cgroup_validator_linux.go
@@ -68,11 +68,9 @@ func getUnifiedMountpoint(path string) (string, bool, error) {
 			// If default unified mount point is available, return it directly.
 			if fields[1] == defaultUnifiedMountPoint {
 				if fields[2] == "tmpfs" {
-					c, err := os.Open(filepath.Join(defaultUnifiedMountPoint, "cgroup.controllers"))
-					if err == nil {
-						defer c.Close()
-					}
-					return defaultUnifiedMountPoint, !os.IsNotExist(err), nil
+					// if `/sys/fs/cgroup/memory` is a dir, this means it uses cgroups v1
+					info, err := os.Stat(filepath.Join(defaultUnifiedMountPoint, "memory"))
+					return defaultUnifiedMountPoint, os.IsNotExist(err) || !info.IsDir(), nil
 				}
 				return defaultUnifiedMountPoint, fields[2] == "cgroup2", nil
 			}

--- a/validators/cgroup_validator_linux.go
+++ b/validators/cgroup_validator_linux.go
@@ -27,8 +27,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-
-	"golang.org/x/sys/unix"
 )
 
 var _ Validator = &CgroupsValidator{}
@@ -50,10 +48,10 @@ const (
 
 // getUnifiedMountpoint checks if the default mount point is available.
 // If not, it parses the mounts file to find a valid cgroup mount point.
-func getUnifiedMountpoint(path string) (string, error) {
+func getUnifiedMountpoint(path string) (string, bool, error) {
 	f, err := os.Open(path)
 	if err != nil {
-		return "", err
+		return "", false, err
 	}
 	defer f.Close()
 	scanner := bufio.NewScanner(f)
@@ -69,7 +67,7 @@ func getUnifiedMountpoint(path string) (string, error) {
 			switch fields[2] {
 			case "cgroup2":
 				// Return the first cgroups v2 mount point directly.
-				return fields[1], nil
+				return fields[1], true, nil
 			case "cgroup":
 				// Set the first cgroups v1 mount point only,
 				// and continue the loop to find if there is a cgroups v2 mount point.
@@ -81,29 +79,22 @@ func getUnifiedMountpoint(path string) (string, error) {
 	}
 	// Return cgroups v1 mount point if no cgroups v2 mount point is found.
 	if len(cgroupV1MountPoint) != 0 {
-		return cgroupV1MountPoint, nil
+		return cgroupV1MountPoint, false, nil
 	}
-	return "", fmt.Errorf("cannot get a cgroupfs mount point from %q", path)
+	return "", false, fmt.Errorf("cannot get a cgroupfs mount point from %q", path)
 }
 
 // Validate is part of the system.Validator interface.
 func (c *CgroupsValidator) Validate(spec SysSpec) (warns, errs []error) {
-	// Get the subsystems from /sys/fs/cgroup/cgroup.controllers when cgroups v2 is used.
-	// /proc/cgroups is meaningless for v2
-	// https://github.com/torvalds/linux/blob/v5.3/Documentation/admin-guide/cgroup-v2.rst#deprecated-v1-core-features
-	var st unix.Statfs_t
-	unifiedMountpoint, err := getUnifiedMountpoint(mountsFilePath)
+	unifiedMountpoint, isCgroupsV2, err := getUnifiedMountpoint(mountsFilePath)
 	if err != nil {
 		return nil, []error{fmt.Errorf("cannot get a cgroup mount point: %w", err)}
-	}
-	if err := unix.Statfs(unifiedMountpoint, &st); err != nil {
-		return nil, []error{fmt.Errorf("cannot statfs the cgroupv2 root: %w", err)}
 	}
 	var requiredCgroupSpec []string
 	var optionalCgroupSpec []string
 	var subsystems []string
 	var warn error
-	if st.Type == unix.CGROUP2_SUPER_MAGIC {
+	if isCgroupsV2 {
 		subsystems, err, warn = c.getCgroupV2Subsystems(unifiedMountpoint)
 		if err != nil {
 			return nil, []error{fmt.Errorf("failed to get cgroups v2 subsystems: %w", err)}

--- a/validators/cgroup_validator_linux.go
+++ b/validators/cgroup_validator_linux.go
@@ -42,8 +42,9 @@ func (c *CgroupsValidator) Name() string {
 }
 
 const (
-	cgroupsConfigPrefix = "CGROUPS_"
-	mountsFilePath      = "/proc/mounts"
+	cgroupsConfigPrefix      = "CGROUPS_"
+	mountsFilePath           = "/proc/mounts"
+	defaultUnifiedMountPoint = "/sys/fs/cgroup"
 )
 
 // getUnifiedMountpoint checks if the default mount point is available.
@@ -64,6 +65,17 @@ func getUnifiedMountpoint(path string) (string, bool, error) {
 		// Example fields: `cgroup2 /sys/fs/cgroup cgroup2 rw,seclabel,nosuid,nodev,noexec,relatime 0 0`.
 		fields := strings.Fields(line)
 		if len(fields) >= 3 {
+			// If default unified mount point is available, return it directly.
+			if fields[1] == defaultUnifiedMountPoint {
+				if fields[2] == "tmpfs" {
+					c, err := os.Open(filepath.Join(defaultUnifiedMountPoint, "cgroup.controllers"))
+					if err == nil {
+						defer c.Close()
+					}
+					return defaultUnifiedMountPoint, !os.IsNotExist(err), nil
+				}
+				return defaultUnifiedMountPoint, fields[2] == "cgroup2", nil
+			}
 			switch fields[2] {
 			case "cgroup2":
 				// Return the first cgroups v2 mount point directly.

--- a/validators/cgroup_validator_test.go
+++ b/validators/cgroup_validator_test.go
@@ -106,7 +106,8 @@ func TestGetUnifiedMountpoint(t *testing.T) {
 		expectedErr         bool
 		expectedPath        string
 		expectedIsCgroupsV2 bool
-		// this may depends on checking `/sys/fs/cgroup/cgroup.controllers`
+		// when /sys/fs/cgroup is mounted as tmpfs,
+		// the cgroup version check depends on checking local dir: `/sys/fs/cgroup/memory`
 		skipIsCgroupsV2Check bool
 	}{
 		"cgroups v2": {


### PR DESCRIPTION
/kind bug 
quick fix and needs verify


the failed CI `/proc/mounts`： see https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/128174/pull-kubernetes-cos-cgroupv1-containerd-node-e2e/1847150504468025344.

```
 /proc/mounts: tmpfs /run tmpfs rw,nosuid,nodev,size=803108k,nr_inodes=819200,mode=755 0 0
 /proc/mounts: tmpfs /sys/fs/cgroup tmpfs ro,nosuid,nodev,noexec,size=4096k,nr_inodes=1024,mode=755 0 0
 /proc/mounts: cgroup2 /sys/fs/cgroup/unified cgroup2 rw,nosuid,nodev,noexec,relatime,nsdelegate 0 0
 /proc/mounts: cgroup /sys/fs/cgroup/systemd cgroup rw,nosuid,nodev,noexec,relatime,xattr,name=systemd 0 0
 /proc/mounts: pstore /sys/fs/pstore pstore rw,nosuid,nodev,noexec,relatime 0 0
 /proc/mounts: bpf /sys/fs/bpf bpf rw,nosuid,nodev,noexec,relatime,mode=700 0 0
 /proc/mounts: cgroup /sys/fs/cgroup/freezer cgroup rw,nosuid,nodev,noexec,relatime,freezer 0 0
 /proc/mounts: cgroup /sys/fs/cgroup/net_cls,net_prio cgroup rw,nosuid,nodev,noexec,relatime,net_cls,net_prio 0 0
 /proc/mounts: cgroup /sys/fs/cgroup/hugetlb cgroup rw,nosuid,nodev,noexec,relatime,hugetlb 0 0
 /proc/mounts: cgroup /sys/fs/cgroup/memory cgroup rw,nosuid,nodev,noexec,relatime,memory 0 0
 /proc/mounts: cgroup /sys/fs/cgroup/cpu,cpuacct cgroup rw,nosuid,nodev,noexec,relatime,cpu,cpuacct 0 0
 /proc/mounts: cgroup /sys/fs/cgroup/perf_event cgroup rw,nosuid,nodev,noexec,relatime,perf_event 0 0
 /proc/mounts: cgroup /sys/fs/cgroup/pids cgroup rw,nosuid,nodev,noexec,relatime,pids 0 0
 /proc/mounts: cgroup /sys/fs/cgroup/rdma cgroup rw,nosuid,nodev,noexec,relatime,rdma 0 0
 /proc/mounts: cgroup /sys/fs/cgroup/blkio cgroup rw,nosuid,nodev,noexec,relatime,blkio 0 0
 /proc/mounts: cgroup /sys/fs/cgroup/cpuset cgroup rw,nosuid,nodev,noexec,relatime,cpuset 0 0
 /proc/mounts: cgroup /sys/fs/cgroup/devices cgroup rw,nosuid,nodev,noexec,relatime,devices 0 0
```

The cri-o cgroupv1 env.

I also checked another env using RHEL 8
```
[root@localhost ~]# cat /etc/os-release
NAME="Red Hat Enterprise Linux"
VERSION="8.4 (Ootpa)"
ID="rhel"
ID_LIKE="fedora"
VERSION_ID="8.4"
PLATFORM_ID="platform:el8"
PRETTY_NAME="Red Hat Enterprise Linux 8.4 (Ootpa)"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:redhat:enterprise_linux:8.4:GA"
HOME_URL="https://www.redhat.com/"
DOCUMENTATION_URL="https://access.redhat.com/documentation/red_hat_enterprise_linux/8/"
BUG_REPORT_URL="https://bugzilla.redhat.com/"

REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 8"
REDHAT_BUGZILLA_PRODUCT_VERSION=8.4
REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
REDHAT_SUPPORT_PRODUCT_VERSION="8.4"
[root@localhost ~]# cat /proc/mounts | grep cgroup
tmpfs /sys/fs/cgroup tmpfs ro,seclabel,nosuid,nodev,noexec,mode=755 0 0
cgroup /sys/fs/cgroup/systemd cgroup rw,seclabel,nosuid,nodev,noexec,relatime,xattr,release_agent=/usr/lib/systemd/systemd-cgroups-agent,name=systemd 0 0
cgroup /sys/fs/cgroup/net_cls,net_prio cgroup rw,seclabel,nosuid,nodev,noexec,relatime,net_cls,net_prio 0 0
cgroup /sys/fs/cgroup/blkio cgroup rw,seclabel,nosuid,nodev,noexec,relatime,blkio 0 0
cgroup /sys/fs/cgroup/memory cgroup rw,seclabel,nosuid,nodev,noexec,relatime,memory 0 0
cgroup /sys/fs/cgroup/cpu,cpuacct cgroup rw,seclabel,nosuid,nodev,noexec,relatime,cpu,cpuacct 0 0
cgroup /sys/fs/cgroup/rdma cgroup rw,seclabel,nosuid,nodev,noexec,relatime,rdma 0 0
cgroup /sys/fs/cgroup/cpuset cgroup rw,seclabel,nosuid,nodev,noexec,relatime,cpuset 0 0
cgroup /sys/fs/cgroup/hugetlb cgroup rw,seclabel,nosuid,nodev,noexec,relatime,hugetlb 0 0
cgroup /sys/fs/cgroup/perf_event cgroup rw,seclabel,nosuid,nodev,noexec,relatime,perf_event 0 0
cgroup /sys/fs/cgroup/devices cgroup rw,seclabel,nosuid,nodev,noexec,relatime,devices 0 0
cgroup /sys/fs/cgroup/freezer cgroup rw,seclabel,nosuid,nodev,noexec,relatime,freezer 0 0
cgroup /sys/fs/cgroup/pids cgroup rw,seclabel,nosuid,nodev,noexec,relatime,pids 0 0
```