### PR TITLE
Use `unix.Uname` instead of exec'ing `uname`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.16
 require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/stretchr/testify v1.3.0
+	golang.org/x/sys v0.27.0
 )

--- a/go.sum
+++ b/go.sum
@@ -7,3 +7,5 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+golang.org/x/sys v0.27.0 h1:wBqf8DvsY9Y/2P8gAfPDEYNuS30J4lPHJxXSb/nJZ+s=
+golang.org/x/sys v0.27.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/validators/package_validator_linux.go
+++ b/validators/package_validator_linux.go
@@ -159,15 +159,6 @@ func (validator *packageValidator) validate(packageSpecs []PackageSpec, manager 
 	return nil, errs
 }
 
-// getKernelRelease returns the kernel release of the local machine.
-func getKernelRelease() (string, error) {
-	output, err := exec.Command("uname", "-r").Output()
-	if err != nil {
-		return "", fmt.Errorf("failed to get kernel release: %w", err)
-	}
-	return strings.TrimSpace(string(output)), nil
-}
-
 // getOSDistro returns the OS distro of the local machine.
 func getOSDistro() (string, error) {
 	f := "/etc/lsb-release"

--- a/validators/types_unix.go
+++ b/validators/types_unix.go
@@ -20,8 +20,10 @@ limitations under the License.
 package system
 
 import (
-	"os/exec"
+	"fmt"
 	"strings"
+
+	"golang.org/x/sys/unix"
 )
 
 // DefaultSysSpec is the default SysSpec for Linux
@@ -96,9 +98,15 @@ var _ KernelValidatorHelper = &KernelValidatorHelperImpl{}
 
 // GetKernelReleaseVersion returns the kernel release version (ex. 4.4.0-96-generic) as a string
 func (o *KernelValidatorHelperImpl) GetKernelReleaseVersion() (string, error) {
-	releaseVersion, err := exec.Command("uname", "-r").CombinedOutput()
+	return getKernelRelease()
+}
+
+// getKernelRelease returns the kernel release of the local machine.
+func getKernelRelease() (string, error) {
+	var utsname unix.Utsname
+	err := unix.Uname(&utsname)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to get kernel release: %w", err)
 	}
-	return strings.TrimSpace(string(releaseVersion)), nil
+	return strings.TrimSpace(unix.ByteSliceToString(utsname.Release[:])), nil
 }


### PR DESCRIPTION
Instead of execing the `uname(1)` command, use the `uname(2)` syscall directly by means of the `unix.Uname` wrapper function to get the kernel release.