### PR TITLE
update kernel LTS status as 4.19 is end of life

### DIFF
--- a/validators/kernel_validator_test.go
+++ b/validators/kernel_validator_test.go
@@ -31,12 +31,22 @@ func TestValidateKernelVersion(t *testing.T) {
 	// they may be different.
 	// This is fine, because the test mainly tests the kernel version validation logic,
 	// not the DefaultSysSpec. The DefaultSysSpec should be tested with node e2e.
-	testRegex := []string{`^4\.19.*$`, `^4\.[2-9][0-9].*$`, `^([5-9]|[1-9][0-9]+)\.([0-9]+)\.([0-9]+).*$`}
+	testRegex := []string{`^5\.4.*$`, `^5\.10.*$`, `^5\.15.*$`, `^([6-9]|[1-9][0-9]+)\.([0-9]+)\.([0-9]+).*$`}
 	for _, test := range []struct {
 		name    string
 		version string
 		err     bool
 	}{
+		{
+			name:    "2.0.0 no version regex matches",
+			version: "2.0.0",
+			err:     true,
+		},
+		{
+			name:    "3.9.0 no version regex matches",
+			version: "3.9.0",
+			err:     true,
+		},
 		{
 			name:    "3.19.9-99-test no version regex matches",
 			version: "3.19.9-99-test",
@@ -48,38 +58,53 @@ func TestValidateKernelVersion(t *testing.T) {
 			err:     true,
 		},
 		{
-			name:    "4.7.1 no version regex matches",
-			version: "4.7.1",
-			err:     true,
-		},
-		{
 			name:    "4.17.3 no version regex matches",
 			version: "4.17.3",
 			err:     true,
 		},
 		{
-			name:    "4.19.3-99-test matches",
+			name:    "4.19.3-99-test no version regex matches",
 			version: "4.19.3-99-test",
-			err:     false,
-		},
-		{
-			name:    "4.20.3+ matches",
-			version: "4.20.3+",
-			err:     false,
-		},
-		{
-			name:    "5.12.3 matches",
-			version: "5.12.3",
-			err:     false,
-		},
-		{
-			name:    "2.0.0 no version regex matches",
-			version: "2.0.0",
 			err:     true,
 		},
 		{
-			name:    "5.0.0 one of version regexes matches",
+			name:    "4.20.3+ no version regex matches",
+			version: "4.20.3+",
+			err:     true,
+		},
+		{
+			name:    "5.0.0 no version regexes matches",
 			version: "5.0.0",
+			err:     true,
+		},
+		{
+			name:    "5.4.288 matches",
+			version: "5.4.288",
+			err:     false,
+		},
+		{
+			name:    "5.10.232 matches",
+			version: "5.10.232",
+			err:     false,
+		},
+		{
+			name:    "5.12.3 no version regex matches(no lts version)",
+			version: "5.12.3",
+			err:     true,
+		},
+		{
+			name:    "5.15.175 matches",
+			version: "5.15.175",
+			err:     false,
+		},
+		{
+			name:    "5.16.3 no version regex matches(no such version)",
+			version: "5.16.3",
+			err:     true,
+		},
+		{
+			name:    "6.12.8 matches",
+			version: "6.12.8",
 			err:     false,
 		},
 		{
@@ -91,11 +116,6 @@ func TestValidateKernelVersion(t *testing.T) {
 			name:    "99.12.12 one of version regexes matches",
 			version: "99.12.12",
 			err:     false,
-		},
-		{
-			name:    "3.9.0 no version regex matches",
-			version: "3.9.0",
-			err:     true,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/validators/types_unix.go
+++ b/validators/types_unix.go
@@ -30,7 +30,7 @@ var DefaultSysSpec = SysSpec{
 	KernelSpec: KernelSpec{
 		// 5.4, 5.10, 5.15 is an active kernel Long Term Support (LTS) release, tracked in https://www.kernel.org/category/releases.html.
 		Versions:     []string{`^5\.4.*$`, `^5\.10.*$`, `^5\.15.*$`, `^([6-9]|[1-9][0-9]+)\.([0-9]+)\.([0-9]+).*$`},
-		VersionsNote: "LTS versions from the 5.x series are 5.4, 5.10 and 5.15. Any 6.x versions are also supported. For cgroups v2 support, the minimal version is 4.15 and the recommended version is 5.8+",
+		VersionsNote: "Supported LTS versions from the 5.x series are 5.4, 5.10 and 5.15. Any 6.x version is also supported. For cgroups v2 support, the recommended version is 5.10 or newer",
 		// TODO(random-liu): Add more config
 		// TODO(random-liu): Add description for each kernel configuration:
 		Required: []KernelConfig{

--- a/validators/types_unix.go
+++ b/validators/types_unix.go
@@ -28,9 +28,9 @@ import (
 var DefaultSysSpec = SysSpec{
 	OS: "Linux",
 	KernelSpec: KernelSpec{
-		// 4.19 is an active kernel Long Term Support (LTS) release, tracked in https://www.kernel.org/category/releases.html.
-		Versions:     []string{`^4\.19.*$`, `^4\.[2-9][0-9].*$`, `^([5-9]|[1-9][0-9]+)\.([0-9]+)\.([0-9]+).*$`},
-		VersionsNote: "Recommended LTS version from the 4.x series is 4.19. Any 5.x or 6.x versions are also supported. For cgroups v2 support, the minimal version is 4.15 and the recommended version is 5.8+",
+		// 5.4, 5.10, 5.15 is an active kernel Long Term Support (LTS) release, tracked in https://www.kernel.org/category/releases.html.
+		Versions:     []string{`^5\.4.*$`, `^5\.10.*$`, `^5\.15.*$`, `^([6-9]|[1-9][0-9]+)\.([0-9]+)\.([0-9]+).*$`},
+		VersionsNote: "LTS versions from the 5.x series are 5.4, 5.10 and 5.15. Any 6.x versions are also supported. For cgroups v2 support, the minimal version is 4.15 and the recommended version is 5.8+",
 		// TODO(random-liu): Add more config
 		// TODO(random-liu): Add description for each kernel configuration:
 		Required: []KernelConfig{


### PR DESCRIPTION
- https://endoflife.date/linux
- https://www.kernel.org/category/releases.html


Version | Maintainer | Released | Projected EOL
-- | -- | -- | --
6.12 | Greg Kroah-Hartman & Sasha Levin | 2024-11-17 | Dec, 2026
6.6 | Greg Kroah-Hartman & Sasha Levin | 2023-10-29 | Dec, 2026
6.1 | Greg Kroah-Hartman & Sasha Levin | 2022-12-11 | Dec, 2027
5.15 | Greg Kroah-Hartman & Sasha Levin | 2021-10-31 | Dec, 2026
5.10 | Greg Kroah-Hartman & Sasha Levin | 2020-12-13 | Dec, 2026
5.4 | Greg Kroah-Hartman & Sasha Levin | 2019-11-24 | Dec, 2025

The maintenance period of the kernel seems shorter than I expected.



