### PR TITLE
Remove cgroup v1/v2 only Kernel Config checks

### DIFF
--- a/validators/types_unix.go
+++ b/validators/types_unix.go
@@ -42,12 +42,6 @@ var DefaultSysSpec = SysSpec{
 			{Name: "IPC_NS"},
 			{Name: "UTS_NS"},
 			{Name: "CGROUPS"},
-			{Name: "CGROUP_BPF"},     // cgroups v2
-			{Name: "CGROUP_CPUACCT"}, // cgroups v1 cpuacct
-			{Name: "CGROUP_DEVICE"},
-			{Name: "CGROUP_FREEZER"}, // cgroups v1 freezer
-			{Name: "CGROUP_PIDS"},
-			{Name: "CGROUP_SCHED"}, // cgroups v1 & v2 cpu
 			{Name: "CPUSETS"},
 			{Name: "MEMCG"},
 			{Name: "INET"},
@@ -62,7 +56,6 @@ var DefaultSysSpec = SysSpec{
 			{Name: "AUFS_FS", Description: "Required for aufs."},
 			{Name: "BLK_DEV_DM", Description: "Required for devicemapper."},
 			{Name: "CFS_BANDWIDTH", Description: "Required for CPU quota."},
-			{Name: "CGROUP_HUGETLB", Description: "Required for hugetlb cgroup."},
 			{Name: "SECCOMP", Description: "Required for seccomp."},
 			{Name: "SECCOMP_FILTER", Description: "Required for seccomp mode 2."},
 		},


### PR DESCRIPTION
https://man7.org/linux/man-pages/man7/cgroups.7.html (search `in Linux 5.2 and
              earlier).`)

https://github.com/kubernetes/system-validators/issues/51#issuecomment-3285257204

To make it cherry-pickable, I opened this PR. 


