### PR TITLE
cgroup_validator: add a KubeletVersion field

### DIFF
--- a/validators/cgroup_validator_linux.go
+++ b/validators/cgroup_validator_linux.go
@@ -26,13 +26,16 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/blang/semver/v4"
 )
 
 var _ Validator = &CgroupsValidator{}
 
 // CgroupsValidator validates cgroup configuration.
 type CgroupsValidator struct {
-	Reporter Reporter
+	Reporter       Reporter
+	KubeletVersion string
 }
 
 // Name is part of the system.Validator interface.
@@ -114,7 +117,22 @@ func (c *CgroupsValidator) Validate(spec SysSpec) (warns, errs []error) {
 		requiredCgroupSpec = spec.CgroupsV2
 		optionalCgroupSpec = spec.CgroupsV2Optional
 	} else {
-		errs = append(errs, errors.New("cgroups v1 support is deprecated and will be removed in a future release. Please migrate to cgroups v2. To explicitly enable cgroups v1 support, you must set the kubelet configuration option 'FailCgroupV1' to 'false'. For more information see https://git.k8s.io/enhancements/keps/sig-node/5573-remove-cgroup-v1"))
+		v1DisabledInKubelet, err := c.isCgroupsV1DisabledInKubelet()
+		if err != nil {
+			return nil, []error{err}
+		}
+
+		v1Error := errors.New("cgroups v1 support is deprecated and will be removed in a future release. " +
+			"Please migrate to cgroups v2. To explicitly enable cgroups v1 support for kubelet v1.35 or newer, " +
+			"you must set the kubelet configuration option 'FailCgroupV1' to 'false'. You must also explicitly " +
+			"skip this validation. For more information, see https://git.k8s.io/enhancements/keps/sig-node/5573-remove-cgroup-v1")
+
+		if v1DisabledInKubelet {
+			errs = append(errs, v1Error)
+		} else {
+			warns = append(warns, v1Error)
+		}
+
 		subsystems, err = c.getCgroupV1Subsystems()
 		if err != nil {
 			return nil, []error{fmt.Errorf("failed to get cgroups v1 subsystems: %w", err)}
@@ -228,4 +246,25 @@ func checkCgroupV2Freeze(unifiedMountpoint string) (isCgroupfs bool, warn error)
 	}
 	isCgroupfs = true
 	return
+}
+
+// isCgroupsV1DisabledInKubelet checks the KubeletVersion and determines if that version
+// disabled cgroups v1 support by default:
+// - If the version is newer than 1.35 pre-release, return true.
+// - If the version is not defined or older than pre-release 1.35, return false.
+func (c *CgroupsValidator) isCgroupsV1DisabledInKubelet() (bool, error) {
+	if c.KubeletVersion == "" {
+		return false, nil
+	}
+
+	kv, err := semver.Parse(c.KubeletVersion)
+	if err != nil {
+		return false, fmt.Errorf("malformed KubeletVersion in CgroupsValidator: %w", err)
+	}
+
+	if kv.Compare(semver.MustParse("1.35.0-0")) > -1 {
+		return true, nil
+	}
+
+	return false, nil
 }

--- a/validators/cgroup_validator_other.go
+++ b/validators/cgroup_validator_other.go
@@ -27,7 +27,8 @@ const mountsFilePath = ""
 
 // CgroupsValidator validates cgroup configuration.
 type CgroupsValidator struct {
-	Reporter Reporter
+	Reporter       Reporter
+	KubeletVersion string
 }
 
 // Validate is part of the system.Validator interface.


### PR DESCRIPTION
    Add a KubeletVersion to the validator struct. This allows
    to parse the version and make a decision to show a warning
    or an error. Add a new function isCgroupsV1DisabledInKubelet
    that does that and include unit tests for it.

fixes https://github.com/kubernetes/system-validators/issues/58

once this merges we need to update kubeadm to pass set the new KubelerVersion field.

